### PR TITLE
optee_ftpm (TPM2) support using REE FS secure filesystem and includes dependency on ms-tpm-20-ref source

### DIFF
--- a/platform/include/Admin.h
+++ b/platform/include/Admin.h
@@ -51,6 +51,8 @@
 #include <stdint.h>
 #include <trace.h>
 #include "swap.h"
+// PERLE - added includes
+#include "BaseTypes.h"
 #include "TpmProfile.h"
 #include "TpmSal.h"
 #include "TpmError.h"

--- a/platform/include/PlatformData.h
+++ b/platform/include/PlatformData.h
@@ -38,6 +38,9 @@
 #ifndef _PLATFORM_DATA_H_
 #define _PLATFORM_DATA_H_
 
+// PERLE - new includes
+#include <stdint.h>
+#include "BaseTypes.h"
 
 #include      "TpmProfile.h"
 

--- a/platform/include/Platform_fp.h
+++ b/platform/include/Platform_fp.h
@@ -40,6 +40,9 @@
 #ifndef    _PLATFORM_FP_H_
 #define    _PLATFORM_FP_H_
 
+// PERLE - added macros include
+#include "GpMacros.h"
+
 //** From EPS.c
 
 LIB_EXPORT void

--- a/sub.mk
+++ b/sub.mk
@@ -9,8 +9,8 @@ CFG_FTPM_TA_TEE_STORAGE_ID ?= TEE_STORAGE_PRIVATE
 # files here will make sure the correct files are used first.
 #
 
-cppflags-y += -include reference/include/VendorString.h
-cppflags-y += -include platform/include/Platform.h
+# PERLE cppflags-y += -include reference/include/VendorString.h
+# PERLE cppflags-y += -include platform/include/Platform.h
 
 cppflags-y += -DHASH_LIB=MBEDTLS -DSYM_LIB=TEE -DMATH_LIB=TEE
 cppflags-y += -DALG_CAMELLIA=ALG_NO -DALG_KDF2=ALG_NO
@@ -31,10 +31,15 @@ endif
 global-incdirs-y += include
 global-incdirs-y += reference/include
 global-incdirs-y += platform/include
+# PERLE - new include paths
+# global-incdirs-y += $(CFG_MS_TPM_20_REF)/TPMCmd/TpmConfiguration
 
 global-incdirs_ext-y += $(CFG_MS_TPM_20_REF)/TPMCmd/tpm/include
 global-incdirs_ext-y += $(CFG_MS_TPM_20_REF)/TPMCmd/tpm/include/prototypes
 global-incdirs_ext-y += $(CFG_MS_TPM_20_REF)/TPMCmd/Platform/include
+# PERLE - new include paths
+# global-incdirs_ext-y += $(CFG_MS_TPM_20_REF)/TPMCmd/tpm/include/private
+# global-incdirs_ext-y += $(CFG_MS_TPM_20_REF)/TPMCmd/TpmConfiguration
 
 cflags-y += -Wno-cast-align
 cflags-y += -Wno-implicit-fallthrough
@@ -265,15 +270,18 @@ srcs_ext-y += crypt/CryptSmac.c
 srcs_ext-y += crypt/CryptEccData.c
 srcs_ext-y += crypt/CryptCmac.c
 srcs_ext-y += crypt/BnMath.c
+# PERLE srcs_ext-y += ../cryptolibs/TpmBigNum/BnMath.c
 srcs_ext-y += crypt/CryptEccSignature.c
 srcs_ext-y += crypt/AlgorithmTests.c
 srcs_ext-y += crypt/CryptSelfTest.c
 srcs_ext-y += crypt/Ticket.c
 srcs_ext-y += crypt/CryptDes.c
 srcs_ext-y += crypt/BnMemory.c
+# PERLE srcs_ext-y += ../cryptolibs/TpmBigNum/BnMemory.c
 srcs_ext-y += crypt/CryptPrimeSieve.c
 srcs_ext-y += crypt/CryptEccKeyExchange.c
 srcs_ext-y += crypt/BnConvert.c
+# PERLE srcs_ext-y += ../cryptolibs/TpmBigNum/BnConvert.c
 srcs_ext-y += crypt/CryptRand.c
 srcs_ext-y += crypt/CryptEccMain.c
 srcs_ext-y += crypt/CryptSym.c

--- a/user_ta.mk
+++ b/user_ta.mk
@@ -1,0 +1,2 @@
+user-ta-uuid := bc50d971-d4c9-42c4-82cb-343fb7f37896
+user-ta-version := 0


### PR DESCRIPTION
We need to pull in specific versions of optee_ftpm, optee_client (tee-supplicant), and ms-tpm-20-ref and fixup some compile issues. Make options were crafted for REE FS (encrypted secure filesystem in linux rootfs located under /var/lib/tee). Decided to fork copies of all the needed repos and create psl-master branches.